### PR TITLE
Add tab control functionality with buttons

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,0 +1,13 @@
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message.action === "closeTab") {
+    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+      chrome.tabs.remove(tabs[0].id)
+    })
+  }
+
+  if (message.action === "refreshTab") {
+    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+      chrome.tabs.reload(tabs[0].id)
+    })
+  }
+})

--- a/content.js
+++ b/content.js
@@ -1,0 +1,51 @@
+// Create buttons container
+const buttonContainer = document.createElement("div")
+buttonContainer.style.position = "fixed"
+buttonContainer.style.bottom = "20px"
+buttonContainer.style.right = "20px"
+buttonContainer.style.zIndex = "9999"
+buttonContainer.style.display = "flex"
+buttonContainer.style.gap = "10px"
+
+// Create Close button
+const closeBtn = document.createElement("button")
+closeBtn.textContent = "Close Tab"
+closeBtn.style.padding = "10px 15px"
+closeBtn.style.background = "#ff4444"
+closeBtn.style.color = "white"
+closeBtn.style.border = "none"
+closeBtn.style.borderRadius = "5px"
+closeBtn.style.cursor = "pointer"
+
+// Create Refresh button
+const refreshBtn = document.createElement("button")
+refreshBtn.textContent = "Refresh"
+refreshBtn.style.padding = "10px 15px"
+refreshBtn.style.background = "#00C851"
+refreshBtn.style.color = "white"
+refreshBtn.style.border = "none"
+refreshBtn.style.borderRadius = "5px"
+refreshBtn.style.cursor = "pointer"
+
+// Add hover effects
+closeBtn.addEventListener("mouseover", () => (closeBtn.style.opacity = "0.8"))
+closeBtn.addEventListener("mouseout", () => (closeBtn.style.opacity = "1"))
+refreshBtn.addEventListener(
+  "mouseover",
+  () => (refreshBtn.style.opacity = "0.8")
+)
+refreshBtn.addEventListener("mouseout", () => (refreshBtn.style.opacity = "1"))
+
+// Add functionality
+closeBtn.addEventListener("click", () => {
+  chrome.runtime.sendMessage({ action: "closeTab" })
+})
+
+refreshBtn.addEventListener("click", () => {
+  chrome.runtime.sendMessage({ action: "refreshTab" })
+})
+
+// Append elements to page
+buttonContainer.appendChild(refreshBtn)
+buttonContainer.appendChild(closeBtn)
+document.body.appendChild(buttonContainer)

--- a/content.js
+++ b/content.js
@@ -1,7 +1,7 @@
 // Create buttons container
 const buttonContainer = document.createElement("div")
 buttonContainer.style.position = "fixed"
-buttonContainer.style.bottom = "20px"
+buttonContainer.style.top = "20px"
 buttonContainer.style.right = "20px"
 buttonContainer.style.zIndex = "9999"
 buttonContainer.style.display = "flex"

--- a/content.js
+++ b/content.js
@@ -1,15 +1,15 @@
 // Create buttons container
 const buttonContainer = document.createElement("div")
 buttonContainer.style.position = "fixed"
-buttonContainer.style.top = "20px"
-buttonContainer.style.right = "20px"
+buttonContainer.style.top = "10px"
+buttonContainer.style.right = "10px"
 buttonContainer.style.zIndex = "9999"
 buttonContainer.style.display = "flex"
 buttonContainer.style.gap = "10px"
 
 // Create Close button
 const closeBtn = document.createElement("button")
-closeBtn.textContent = "Close Tab"
+closeBtn.textContent = "Close"
 closeBtn.style.padding = "10px 15px"
 closeBtn.style.background = "#ff4444"
 closeBtn.style.color = "white"

--- a/manifest.json
+++ b/manifest.json
@@ -1,10 +1,17 @@
 {
   "manifest_version": 3,
-  "name": "Tab Control",
+  "name": "Page Control",
   "version": "1.0",
-  "description": "Close and refresh tabs quickly",
-  "action": {
-    "default_popup": "popup.html"
-  },
-  "permissions": ["tabs", "scripting"]
+  "description": "Adds control buttons to every page",
+  "permissions": ["tabs", "scripting"],
+  "host_permissions": ["<all_urls>"],
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content.js"]
+    }
+  ],
+  "background": {
+    "service_worker": "background.js"
+  }
 }


### PR DESCRIPTION
Implement background and content scripts to enable tab closing and refreshing through newly created buttons on web pages. Update the manifest to reflect these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added floating "Close" and "Refresh" buttons to every webpage for quick tab management.
  - Introduced background processing to handle tab closing and refreshing actions.
- **Enhancements**
  - Updated extension name and description for improved clarity.
- **Improvements**
  - Expanded permissions to support functionality across all websites.
  - Removed the popup interface to streamline user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->